### PR TITLE
Doubled boot call causes error in destroy

### DIFF
--- a/packages/phaser-navmesh/src/phaser-navmesh-plugin.ts
+++ b/packages/phaser-navmesh/src/phaser-navmesh-plugin.ts
@@ -14,7 +14,6 @@ export default class PhaserNavMeshPlugin extends Phaser.Plugins.ScenePlugin {
 
   public constructor(scene: Phaser.Scene, pluginManager: Phaser.Plugins.PluginManager) {
     super(scene, pluginManager);
-    if (!scene.sys.settings.isBooted) this.systems.events.once("boot", this.boot, this);
   }
 
   /** Phaser.Scene lifecycle event */


### PR DESCRIPTION
@mikewesthad Here's a PR to fix a double boot call that occurs if the scene is added before the system is booted.

Here's an example of the error. If you load this up and then click the "game" it will throw an error because destroy is called twice and systems is undefined on the second call.

```
import Phaser from 'phaser';
import PhaserNavMeshPlugin from 'phaser-navmesh/src';

const config = {
  type: Phaser.AUTO,
  width: 800,
  height: 500,
  scale: {
    mode: Phaser.Scale.FIT,
    autoCenter: Phaser.Scale.CENTER_BOTH
  },
  plugins: {
    scene: [
      {
        key: 'PhaserNavMeshPlugin', // Key to store the plugin class under in cache
        plugin: PhaserNavMeshPlugin, // Class that constructs plugins
        mapping: 'navMeshPlugin', // Property mapping to use for the scene, e.g. this.navMeshPlugin
        start: true
      }
    ]
  },
  physics: {
    default: 'arcade',
    arcade: {
      debug: true,
      debugShowBody: true
    }
  }
}

function create(){
  this.input.on('pointerdown', ()=>{
    this.scene.remove('created');
  })
}

const game = new Phaser.Game(config);
game.scene.add('created', {create}, true);
